### PR TITLE
Removed tag: in example config

### DIFF
--- a/config.sample
+++ b/config.sample
@@ -9,7 +9,7 @@ config = {
     'ec2_region_endpoint': 'ec2.eu-west-1.amazonaws.com',
 
     # Tag of the EBS volume you want to take the snapshots of
-    'tag_name': 'tag:MakeSnapshot',
+    'tag_name': 'MakeSnapshot',
     'tag_value': 'True',
 
     # Number of snapshots to keep (the older ones are going to be deleted,


### PR DESCRIPTION
I noticed the 'tag:' part in tag_name should be removed if you use 'MakeSnapshot' for the tag. The script already prepends 'tag:'.
