### PR TITLE
Tag instances instead of volumes, better snapshot tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ aws-snapshot-tool
 =================
 aws-snapshot-tool is a python script to make it easy to *roll snapshot of your EBS volumes*. 
 
-Simply add a tag to each volume you want snapshots of, configure and install a cronjob for aws-snapshot-tool and you are off. It will even handle rolling snapshots on a day, week and year so that you can setup the retention policy to suit.
+Simply add a tag to each instance you want snapshots of, configure and install a cronjob for aws-snapshot-tool and you are off. It will even handle rolling snapshots on a day, week and year so that you can setup the retention policy to suit.
 
 Features:
 - *Python based*: Leverages boto and is easy to configure and install as a crontab
@@ -21,7 +21,7 @@ Usage
 7. Decide how many versions of the snapshots you want for day/week/month and change this in config.py
 8. Change the Region and Endpoint for AWS in the config.py file
 9. Optionally specify a proxy if you need to, otherwise set it to '' in the config.py
-10. Give every Volume for which you want snapshots a Tag with a Key and a Value and put these in the config file. Default: "MakeSnapshot" and the value "True"
+10. Give every Instance for which you want snapshots a Tag with a Key and a Value and put these in the config file. Default: "MakeSnapshot" and the value "True"
 11. Install the script in the cron: 
 
 		# chmod +x makesnapshots.py

--- a/config.sample
+++ b/config.sample
@@ -9,7 +9,7 @@ config = {
     'ec2_region_endpoint': 'ec2.eu-west-1.amazonaws.com',
 
     # Tag of the EBS volume you want to take the snapshots of
-    'tag_name': 'tag:MakeSnapshot',
+    'tag_name': 'MakeSnapshot',
     'tag_value': 'True',
 
     # Number of snapshots to keep (the older ones are going to be deleted,

--- a/makesnapshots.py
+++ b/makesnapshots.py
@@ -159,6 +159,7 @@ for i in insts:
             count_total += 1
             logging.info(vol)
             tags_volume = get_resource_tags(vol.id)
+			# Detailed info for 'description' tag
             description = 'BACKUP:%(instName)s %(period)s_snapshot %(vol_id)s_%(period)s_%(date_suffix)s by snapshot script at %(date)s' % {
                 'instName': instName,
             'period': period,
@@ -169,6 +170,7 @@ for i in insts:
             try:
                 current_snap = vol.create_snapshot(description)
                 set_resource_tags(current_snap, tags_volume)
+				# Uses instance name for snapshot name
 			    set_resource_tags(current_snap, {"Name":instName})
                 suc_message = 'Snapshot created with description: %s and tags: %s' % (description, str(tags_volume))
                 print '     ' + suc_message

--- a/makesnapshots.py
+++ b/makesnapshots.py
@@ -153,7 +153,7 @@ for i in insts:
             instName= "%s" % i.tags['Name']
         else:
             instName= "%s" % i.id
-    # Snapshot of each volume attached to the instance
+    # Iterate through each volume attached to the selected instances
     for vol in volumes:
         try:
             count_total += 1
@@ -162,13 +162,15 @@ for i in insts:
 			# Detailed info for 'description' tag
             description = 'BACKUP:%(instName)s %(period)s_snapshot %(vol_id)s_%(period)s_%(date_suffix)s by snapshot script at %(date)s' % {
                 'instName': instName,
-            'period': period,
+                'period': period,
                 'vol_id': vol.id,
                 'date_suffix': date_suffix,
                 'date': datetime.today().strftime('%d-%m-%Y %H:%M:%S')
             }
             try:
+			    # Create snapshot
                 current_snap = vol.create_snapshot(description)
+				# Give snapshot the same tags from volume
                 set_resource_tags(current_snap, tags_volume)
 				# Uses instance name for snapshot name
 			    set_resource_tags(current_snap, {"Name":instName})

--- a/makesnapshots.py
+++ b/makesnapshots.py
@@ -229,6 +229,7 @@ for i in insts:
         else:
             count_success += 1
 
+# Result message
 result = '\nFinished making snapshots at %(date)s with %(count_success)s snapshots of %(count_total)s possible.\n\n' % {
     'date': datetime.today().strftime('%d-%m-%Y %H:%M:%S'),
     'count_success': count_success,

--- a/makesnapshots.py
+++ b/makesnapshots.py
@@ -147,83 +147,83 @@ insts = conn.get_only_instances(filters={ 'tag:' + config['tag_name']: config['t
 
 # Iterate through each instance in the list
 for i in insts:
-	# Get all the volumes attached to this instance
-	volumes = conn.get_all_volumes(filters={'attachment.instance-id': i.id})
-	if 'Name' in i.tags:
+    # Get all the volumes attached to this instance
+    volumes = conn.get_all_volumes(filters={'attachment.instance-id': i.id})
+    if 'Name' in i.tags:
             instName= "%s" % i.tags['Name']
         else:
             instName= "%s" % i.id
-	# 
-	for vol in volumes:
-	    try:
-	        count_total += 1
-	        logging.info(vol)
-	        tags_volume = get_resource_tags(vol.id)
-	        description = 'BACKUP:%(instName)s %(period)s_snapshot %(vol_id)s_%(period)s_%(date_suffix)s by snapshot script at %(date)s' % {
-	            'instName': instName,
-		    'period': period,
-	            'vol_id': vol.id,
-	            'date_suffix': date_suffix,
-	            'date': datetime.today().strftime('%d-%m-%Y %H:%M:%S')
-	        }
-	        try:
-	            current_snap = vol.create_snapshot(description)
-	            set_resource_tags(current_snap, tags_volume)
-		    set_resource_tags(current_snap, {"Name":instName})
-	            suc_message = 'Snapshot created with description: %s and tags: %s' % (description, str(tags_volume))
-	            print '     ' + suc_message
-	            logging.info(suc_message)
-	            total_creates += 1
-	        except Exception, e:
-	            print "Unexpected error:", sys.exc_info()[0]
-	            logging.error(e)
-	            pass
-	
-	        snapshots = vol.snapshots()
-	        deletelist = []
-	        for snap in snapshots:
-	            sndesc = snap.description
-	            if (sndesc.find('week_snapshot')==1 and period == 'week'):
-	                deletelist.append(snap)
-	            elif (sndesc.find('day_snapshot')==1 and period == 'day'):
-	                deletelist.append(snap)
-	            elif (sndesc.find('month_snapshot')==1 and period == 'month'):
-	                deletelist.append(snap)
-	            else:
-	                logging.info('     Skipping, not added to deletelist: ' + sndesc)
-	
-	        for snap in deletelist:
-	            logging.info(snap)
-	            logging.info(snap.start_time)
-	
-	        def date_compare(snap1, snap2):
-	            if snap1.start_time < snap2.start_time:
-	                return -1
-	            elif snap1.start_time == snap2.start_time:
-	                return 0
-	            return 1
-	
-	        deletelist.sort(date_compare)
-	        if period == 'day':
-	            keep = keep_day
-	        elif period == 'week':
-	            keep = keep_week
-	        elif period == 'month':
-	            keep = keep_month
-	        delta = len(deletelist) - keep
-	        for i in range(delta):
-	            del_message = '     Deleting snapshot ' + deletelist[i].description
-	            logging.info(del_message)
-	            deletelist[i].delete()
-	            total_deletes += 1
-	        time.sleep(3)
-	    except:
-	        print "Unexpected error:", sys.exc_info()[0]
-	        logging.error('Error in processing volume with id: ' + vol.id)
-	        errmsg += 'Error in processing volume with id: ' + vol.id
-	        count_errors += 1
-	    else:
-	        count_success += 1
+    # Snapshot of each volume attached to the instance
+    for vol in volumes:
+        try:
+            count_total += 1
+            logging.info(vol)
+            tags_volume = get_resource_tags(vol.id)
+            description = 'BACKUP:%(instName)s %(period)s_snapshot %(vol_id)s_%(period)s_%(date_suffix)s by snapshot script at %(date)s' % {
+                'instName': instName,
+            'period': period,
+                'vol_id': vol.id,
+                'date_suffix': date_suffix,
+                'date': datetime.today().strftime('%d-%m-%Y %H:%M:%S')
+            }
+            try:
+                current_snap = vol.create_snapshot(description)
+                set_resource_tags(current_snap, tags_volume)
+			    set_resource_tags(current_snap, {"Name":instName})
+                suc_message = 'Snapshot created with description: %s and tags: %s' % (description, str(tags_volume))
+                print '     ' + suc_message
+                logging.info(suc_message)
+                total_creates += 1
+            except Exception, e:
+                print "Unexpected error:", sys.exc_info()[0]
+                logging.error(e)
+                pass
+    
+            snapshots = vol.snapshots()
+            deletelist = []
+            for snap in snapshots:
+                sndesc = snap.description
+                if (sndesc.find('week_snapshot')==1 and period == 'week'):
+                    deletelist.append(snap)
+                elif (sndesc.find('day_snapshot')==1 and period == 'day'):
+                    deletelist.append(snap)
+                elif (sndesc.find('month_snapshot')==1 and period == 'month'):
+                    deletelist.append(snap)
+                else:
+                    logging.info('     Skipping, not added to deletelist: ' + sndesc)
+    
+            for snap in deletelist:
+                logging.info(snap)
+                logging.info(snap.start_time)
+    
+            def date_compare(snap1, snap2):
+                if snap1.start_time < snap2.start_time:
+                    return -1
+                elif snap1.start_time == snap2.start_time:
+                    return 0
+                return 1
+    
+            deletelist.sort(date_compare)
+            if period == 'day':
+                keep = keep_day
+            elif period == 'week':
+                keep = keep_week
+            elif period == 'month':
+                keep = keep_month
+            delta = len(deletelist) - keep
+            for i in range(delta):
+                del_message = '     Deleting snapshot ' + deletelist[i].description
+                logging.info(del_message)
+                deletelist[i].delete()
+                total_deletes += 1
+            time.sleep(3)
+        except:
+            print "Unexpected error:", sys.exc_info()[0]
+            logging.error('Error in processing volume with id: ' + vol.id)
+            errmsg += 'Error in processing volume with id: ' + vol.id
+            count_errors += 1
+        else:
+            count_success += 1
 
 result = '\nFinished making snapshots at %(date)s with %(count_success)s snapshots of %(count_total)s possible.\n\n' % {
     'date': datetime.today().strftime('%d-%m-%Y %H:%M:%S'),


### PR DESCRIPTION
Now a user tags the actual instance instead of each volume. It is incredibly annoying to have to search for the appropriate volume(s) and tag them.

Also made the snapshot description more detailed and tagged the snapshot with the same name as the instance.
