### PR TITLE
Respect user's python binary

### DIFF
--- a/makesnapshots.py
+++ b/makesnapshots.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # (c) 2012/2014 E.M. van Nuil / Oblivion b.v.
 #


### PR DESCRIPTION
Use "/usr/bin/env python" instead. This small change will make this script work in a virtualenv.