### PR TITLE
Add 'snapshot copy to another region'

### DIFF
--- a/config.sample
+++ b/config.sample
@@ -9,8 +9,12 @@ config = {
     'ec2_region_endpoint': 'ec2.eu-west-1.amazonaws.com',
 
     # Tag of the EBS volume you want to take the snapshots of
-    'tag_name': 'tag:MakeSnapshot',
+    'tag_name': 'MakeSnapshot',
     'tag_value': 'True',
+
+    # Tag of the EBS volume you want to copy to another region
+    # The value of the tag is the AWS region name
+    'copy_tag_name': 'CopySnapshot',
 
     # Number of snapshots to keep (the older ones are going to be deleted,
     # since they cost money).

--- a/makesnapshots.py
+++ b/makesnapshots.py
@@ -233,10 +233,18 @@ for vol in vols:
             deletelist[i].delete()
             if dest_conn:
                 logging.info('     Deleting snapshots copies sourced from the original snapshot: ' + deletelist[i].id)
-                copied_vols = dest_conn.get_all_snapshots(owner='self', filters={ 'tag:source_snapshot_id': deletelist[i].id })
-                for copied_vol in copied_vols:
-                    logging.info('     Deleting copied snapshot: ' + copied_vol.id)
-                    copied_vol.delete()
+                copied_vols = dest_conn.describe_snapshots(
+                    OwnerIds=['self'],
+                    Filters = [
+                        {
+                            'Name': 'tag:source_snapshot_id',
+                            'Values': [deletelist[i].id]
+                        },
+                    ]
+                )
+                for copied_vol in copied_vols['Snapshots']:
+                    logging.info('     Deleting copied snapshot: ' + copied_vol['SnapshotId'])
+                    dest_conn.delete_snapshot(SnapshotId=copied_vol['SnapshotId'])
             total_deletes += 1
         time.sleep(3)
     except:


### PR DESCRIPTION
If you want to ship your snapshot to another AWS instance, you can now do so.

The config.sample has been updated.

The tag: prefix in the tag_name in config.sample has been removed as it's already implied in the code and leads to confusion and broken configs if it is used.
