### PR TITLE
Select volumes by instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Usage
 7. Decide how many versions of the snapshots you want for day/week/month and change this in config.py
 8. Change the Region and Endpoint for AWS in the config.py file
 9. Optionally specify a proxy if you need to, otherwise set it to '' in the config.py
-10. Give every Volume for which you want snapshots a Tag with a Key and a Value and put these in the config file. Default: "MakeSnapshot" and the value "True"
+10. Give every Volume or Instance for which you want snapshots a Tag with a Key and a Value and put these in the config file. Default: "MakeSnapshot" and the value "True"
 11. Install the script in the cron: 
 
 		# chmod +x makesnapshots.py

--- a/config.sample
+++ b/config.sample
@@ -12,6 +12,12 @@ config = {
     'tag_name': 'MakeSnapshot',
     'tag_value': 'True',
 
+    # tag_type 'volume' will cause individual volumes that match the above tag
+    # to be snapshotted.
+    # tag_type 'instance' will cause volumes attached to running instances that
+    # match the above tag to be snapshotted.
+    'tag_type': 'volume',
+
     # Number of snapshots to keep (the older ones are going to be deleted,
     # since they cost money).
     'keep_day': 5,

--- a/config.sample
+++ b/config.sample
@@ -9,7 +9,7 @@ config = {
     'ec2_region_endpoint': 'ec2.eu-west-1.amazonaws.com',
 
     # Tag of the EBS volume you want to take the snapshots of
-    'tag_name': 'tag:MakeSnapshot',
+    'tag_name': 'MakeSnapshot',
     'tag_value': 'True',
 
     # Number of snapshots to keep (the older ones are going to be deleted,


### PR DESCRIPTION
This PR implements the ability to snapshot _all_ volumes attached to running instances that match a given tag, rather than having to tag individual volumes.
