### PR TITLE
IAM security policy format update

### DIFF
--- a/iam.policy.sample
+++ b/iam.policy.sample
@@ -1,7 +1,7 @@
 {
+  "Version": "2012-10-17",
   "Statement": [
 	{
-	  "Sid": "Stmtxxxxxxxxxx",
 	  "Action": [
 		"sns:Publish"
 	  ],
@@ -11,7 +11,6 @@
 	  ]
 	},
 	{
-	  "Sid": "Stmtxxxxxxxxxxxxxx",
 	  "Action": [
 		"ec2:CreateSnapshot",
 		"ec2:CreateTags",


### PR DESCRIPTION
According to the AWS IAM security policy examples [*], AWS is not requiring
anymore the "Sid" field but is requiring the "Version" field.

[*] https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_examples.html#policy_library_ec2